### PR TITLE
Setup Python provider for Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ The installation scripts assume that [Homebrew](https://brew.sh/) is available
 for installing packages. The `install_packages.sh` script will install
 Homebrew for you if it is missing.
 
+Neovim plugins such as UltiSnips require Python 3 with the `pynvim` module.
+The `install_packages.sh` script installs Python through Homebrew and runs
+`pip3 install --user pynvim` so that Neovim can locate its Python provider.
+You can verify the setup from within Neovim using `:checkhealth provider`.
+
 ## Installation
 
 Clone this repository anywhere on your system and run the provided scripts:

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -15,6 +15,7 @@ PACKAGES=(
   git
   mysql
   neovim
+  python
   node
   nvm
   postgresql
@@ -31,6 +32,9 @@ PACKAGES=(
 
 echo 'Installing packages...'
 brew install ${PACKAGES[@]}
+
+echo 'Registering Python provider for Neovim...'
+pip3 install --user pynvim
 
 echo 'Running Cleanup'
 brew cleanup


### PR DESCRIPTION
## Summary
- install Python through Homebrew and register `pynvim`
- document the Python provider requirement in the README

## Testing
- `bash -n scripts/install_packages.sh`
- `bash -n scripts/copy_files.sh`


------
https://chatgpt.com/codex/tasks/task_e_68518b26930c833182c849014fca988c